### PR TITLE
fix restart policy representation

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ use serde_json;
 use std::env;
 use std::io;
 use base64;
+use response;
 
 error_chain! {
     foreign_links {
@@ -16,6 +17,7 @@ error_chain! {
         serde_json::error::Error, Json;
         docker::DockerError, Docker;
         base64::DecodeError, Base64;
+        response::Error, DockerResponse;
     }
 
     errors {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! Docker
-#![doc(html_root_url = "https://ghmlee.github.io/rust-docker/doc")]
-// Increase the compiler's recursion limit for the `error_chain` crate.
+//! Docker Engine API client
+
+// for the `error_chain` crate.
 #![recursion_limit = "1024"]
 
 extern crate base64;


### PR DESCRIPTION
Fix serializer/deserializer of `RestartPolicy` option.
The create container api takes this option as a field of `HostConfig`.
The official api doc sais that `RestartPolicy` is one of `"{}"`, `{"Name":"always",...}`, `{"Name":"unless-stopped",...}` and `{"Name":"on-failure",...}`.
(see https://docs.docker.com/engine/api/v1.26/#operation/ContainerCreate)

But actual output of dockerd violates this document. Default value of this option is represented as `{ "Name":"no", MaxRetryCount: 0}`.
Not only `v1.26`(supported this library) but also `v1.39`(latest).
