### PR TITLE
(WIP) Added support for tty usage of attach.

### DIFF
--- a/examples/attach-container.rs
+++ b/examples/attach-container.rs
@@ -1,7 +1,8 @@
 extern crate dockworker;
 extern crate hyper;
 
-use dockworker::{ContainerCreateOptions, ContainerHostConfig, Docker, container::AttachContainer};
+use dockworker::{ContainerCreateOptions, ContainerHostConfig, Docker, container::AttachContainer,
+                 container::MaybeTtyAttachResponse};
 use std::io::{BufRead, BufReader};
 
 fn main() {
@@ -16,16 +17,18 @@ fn main() {
     let res = docker
         .attach_container(&container.id, None, true, true, false, true, false)
         .unwrap();
-    let cont: AttachContainer = res.into();
-    let mut line_reader = BufReader::new(cont.stdout);
+    if let MaybeTtyAttachResponse::NonTtyResponse(res) = res {
+        let cont: AttachContainer = res.into();
+        let mut line_reader = BufReader::new(cont.stdout);
 
-    loop {
-        let mut line = String::new();
-        let size = line_reader.read_line(&mut line).unwrap();
-        print!("{:4}: {}", size, line);
-        if size == 0 {
-            break;
+        loop {
+            let mut line = String::new();
+            let size = line_reader.read_line(&mut line).unwrap();
+            print!("{:4}: {}", size, line);
+            if size == 0 {
+                break;
+            }
         }
+        println!("");
     }
-    println!("");
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -85,7 +85,7 @@ pub struct Config {
     pub Hostname: String,
     pub Image: String,
     pub Labels: HashMap<String, String>,
-    // TODO: We don't know exacly what this vec contains.
+    // TODO: We don't know exactly what this vec contains.
     //pub OnBuild: Option<Vec<???>>,
     pub OpenStdin: bool,
     pub StdinOnce: bool,
@@ -406,6 +406,11 @@ impl Read for ContainerStdio {
 }
 
 /// Response of attach to container api
+pub enum MaybeTtyAttachResponse {
+    TtyResponse(Response),
+    NonTtyResponse(AttachResponse),
+}
+
 #[derive(Debug)]
 pub struct AttachResponse {
     res: Response,
@@ -414,6 +419,12 @@ pub struct AttachResponse {
 impl AttachResponse {
     pub fn new(res: Response) -> Self {
         Self { res }
+    }
+}
+
+impl From<AttachResponse> for Response {
+    fn from(res: AttachResponse) -> Self {
+        res.res
     }
 }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -393,7 +393,7 @@ impl Docker {
             .post(
                 self.headers(),
                 &format!("/containers/{}/attach?{}", id, param.finish()),
-                ""
+                "",
             )
             .and_then(|res| {
                 if res.status.is_success() {

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -363,6 +363,47 @@ impl Docker {
             })
     }
 
+    /// Attach to a container created with tty=true
+    ///
+    /// Attach to a container to read its output or send it input.
+    ///
+    /// # API
+    /// /containers/{id}/attach
+    #[allow(non_snake_case)]
+    pub fn attach_container_tty(
+        &self,
+        id: &str,
+        detachKeys: Option<&str>,
+        logs: bool,
+        stream: bool,
+        stdin: bool,
+        stdout: bool,
+        stderr: bool,
+    ) -> Result<Response> {
+        let mut param = url::form_urlencoded::Serializer::new(String::new());
+        if let Some(keys) = detachKeys {
+            param.append_pair("detachKeys", keys);
+        }
+        param.append_pair("logs", &logs.to_string());
+        param.append_pair("stream", &stream.to_string());
+        param.append_pair("stdin", &stdin.to_string());
+        param.append_pair("stdout", &stdout.to_string());
+        param.append_pair("stderr", &stderr.to_string());
+        self.http_client()
+            .post(
+                self.headers(),
+                &format!("/containers/{}/attach?{}", id, param.finish()),
+                ""
+            )
+            .and_then(|res| {
+                if res.status.is_success() {
+                    Ok(res)
+                } else {
+                    Err(serde_json::from_reader::<_, DockerError>(res)?.into())
+                }
+            })
+    }
+
     /// Gets current logs and tails logs from a container
     ///
     /// # API


### PR DESCRIPTION
Really need your thoughts on this one. To use the tty mode of attach one needs to read the raw Response object (once a container has been created with tty=true). I've done this as a separate method so it's backward compatible.

It feels like tty containers and non-tty containers are different types... I don't think there's much we can do about that without radical surgery.

Keen to hear other ideas as to how to solve this / reduce duplication.