### PR TITLE
fix Docker::prune_image()

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -706,10 +706,11 @@ impl Docker {
     /// # API
     /// /images/prune
     pub fn prune_image(&self, dangling: bool) -> Result<PrunedImages> {
+        println!("start pruning...dangling? {}", &dangling);
         let mut param = url::form_urlencoded::Serializer::new(String::new());
         param.append_pair(
             "filters",
-            &format!(r#"{{"filters": {{"dangling":{}}} }}"#, dangling.to_string()),
+            &format!(r#"{{ "dangling": {{ "{}": true }} }}"#, dangling.to_string()),
         );
         self.http_client()
             .post(

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -706,7 +706,7 @@ impl Docker {
     /// # API
     /// /images/prune
     pub fn prune_image(&self, dangling: bool) -> Result<PrunedImages> {
-        println!("start pruning...dangling? {}", &dangling);
+        debug!("start pruning...dangling? {}", &dangling);
         let mut param = url::form_urlencoded::Serializer::new(String::new());
         param.append_pair(
             "filters",

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -710,7 +710,10 @@ impl Docker {
         let mut param = url::form_urlencoded::Serializer::new(String::new());
         param.append_pair(
             "filters",
-            &format!(r#"{{ "dangling": {{ "{}": true }} }}"#, dangling.to_string()),
+            &format!(
+                r#"{{ "dangling": {{ "{}": true }} }}"#,
+                dangling.to_string()
+            ),
         );
         self.http_client()
             .post(


### PR DESCRIPTION
Regarding https://github.com/eldesh/dockworker/issues/31, I found a solution. It works under my environment, and it seems correct as long as I checked the official test code:
https://github.com/moby/moby/blob/611b23c1a0e9a9f440165a331964923fd1116256/client/image_prune_test.go#L58-L72