### PR TITLE
restart API and added Health into State struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,15 @@ unix_socket = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
 named_pipe = "0.2.2"
+
+
+# The testing profile, used for `cargo test`.
+[profile.test]
+opt-level = 0
+debug = 2
+rpath = false
+lto = false
+debug-assertions = true
+panic = 'unwind'
+incremental = true
+overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,14 +57,3 @@ unix_socket = "0.5.0"
 [target.'cfg(windows)'.dependencies]
 named_pipe = "0.2.2"
 
-
-# The testing profile, used for `cargo test`.
-[profile.test]
-opt-level = 0
-debug = 2
-rpath = false
-lto = false
-debug-assertions = true
-panic = 'unwind'
-incremental = true
-overflow-checks = true

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,7 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt};
 use errors;
 use hyper_client::Response;
-use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+use serde::de::{self, Deserialize, DeserializeOwned, Deserializer};
 use std;
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
@@ -197,10 +197,14 @@ pub struct LogMessage {
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum HealthState {
-    NoHealthcheck, // Indicates there is no healthcheck
-    Starting,      // Starting indicates that the container is not yet ready
-    Healthy,       // Healthy indicates that the container is running correctly
-    Unhealthy,     // Unhealthy indicates that the container has a problem
+    /// Indicates there is no healthcheck
+    NoHealthcheck,
+    /// Indicates that the container is not yet ready
+    Starting,
+    /// Indicates that the container is running correctly
+    Healthy,
+    /// Indicates that the container has a problem
+    Unhealthy,
 }
 
 impl fmt::Display for HealthState {
@@ -220,7 +224,7 @@ impl<'de> Deserialize<'de> for HealthState {
         D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Ok(HealthState::from_str(&s).unwrap())
+        s.parse().map_err(de::Error::custom)
     }
 }
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -328,6 +328,22 @@ impl Docker {
             .and_then(no_content)
     }
 
+    /// Restart a container
+    ///
+    /// # API
+    /// /containers/{id}/restart
+    pub fn restart_container(&self, id: &str, timeout: Duration) -> Result<()> {
+        let mut param = url::form_urlencoded::Serializer::new(String::new());
+        param.append_pair("t", &timeout.as_secs().to_string());
+        self.http_client()
+            .post(
+                self.headers(),
+                &format!("/containers/{}/restart?{}", id, param.finish()),
+                "",
+            )
+            .and_then(no_content)
+    }
+
     /// Attach to a container
     ///
     /// Attach to a container to read its output or send it input.

--- a/src/fixtures/container_inspect.json
+++ b/src/fixtures/container_inspect.json
@@ -1,0 +1,218 @@
+{
+    "Id": "774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37",
+    "Created": "2016-10-25T11:59:37.858589354Z",
+    "Path": "rails",
+    "Args": [
+        "server",
+        "-b",
+        "0.0.0.0"
+    ],
+    "State": {
+        "Status": "running",
+        "Running": true,
+        "Paused": false,
+        "Restarting": false,
+        "OOMKilled": false,
+        "Dead": false,
+        "Pid": 13038,
+        "ExitCode": 0,
+        "Error": "",
+        "StartedAt": "2016-10-25T11:59:38.261828009Z",
+        "FinishedAt": "0001-01-01T00:00:00Z"
+    },
+    "Image": "sha256:f5e9d349e7e5c0f6de798d732d83fa5e087695cd100149121f01c891e6167c13",
+    "ResolvConfPath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/resolv.conf",
+    "HostnamePath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/hostname",
+    "HostsPath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/hosts",
+    "LogPath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37-json.log",
+    "Name": "/railshello_web_1",
+    "RestartCount": 0,
+    "Driver": "aufs",
+    "MountLabel": "",
+    "ProcessLabel": "",
+    "AppArmorProfile": "",
+    "ExecIDs": null,
+    "HostConfig": {
+        "Binds": [],
+        "ContainerIDFile": "",
+        "LogConfig": {
+            "Type": "json-file",
+            "Config": {}
+        },
+        "NetworkMode": "railshello_default",
+        "PortBindings": {
+            "3000/tcp": [
+                {
+                    "HostIp": "",
+                    "HostPort": "3000"
+                }
+            ]
+        },
+        "RestartPolicy": {
+            "Name": "",
+            "MaximumRetryCount": 0
+        },
+        "AutoRemove": false,
+        "VolumeDriver": "",
+        "VolumesFrom": [],
+        "CapAdd": null,
+        "CapDrop": null,
+        "Dns": null,
+        "DnsOptions": null,
+        "DnsSearch": null,
+        "ExtraHosts": null,
+        "GroupAdd": null,
+        "IpcMode": "",
+        "Cgroup": "",
+        "Links": null,
+        "OomScoreAdj": 0,
+        "PidMode": "",
+        "Privileged": false,
+        "PublishAllPorts": false,
+        "ReadonlyRootfs": false,
+        "SecurityOpt": null,
+        "UTSMode": "",
+        "UsernsMode": "",
+        "ShmSize": 67108864,
+        "Runtime": "runc",
+        "ConsoleSize": [
+            0,
+            0
+        ],
+        "Isolation": "",
+        "CpuShares": 0,
+        "Memory": 0,
+        "CgroupParent": "",
+        "BlkioWeight": 0,
+        "BlkioWeightDevice": null,
+        "BlkioDeviceReadBps": null,
+        "BlkioDeviceWriteBps": null,
+        "BlkioDeviceReadIOps": null,
+        "BlkioDeviceWriteIOps": null,
+        "CpuPeriod": 0,
+        "CpuQuota": 0,
+        "CpusetCpus": "",
+        "CpusetMems": "",
+        "Devices": null,
+        "DiskQuota": 0,
+        "KernelMemory": 0,
+        "MemoryReservation": 0,
+        "MemorySwap": 0,
+        "MemorySwappiness": -1,
+        "OomKillDisable": false,
+        "PidsLimit": 0,
+        "Ulimits": null,
+        "CpuCount": 0,
+        "CpuPercent": 0,
+        "IOMaximumIOps": 0,
+        "IOMaximumBandwidth": 0
+    },
+    "GraphDriver": {
+        "Name": "aufs",
+        "Data": null
+    },
+    "Mounts": [],
+    "Config": {
+        "Hostname": "774758ca1db8",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": {
+            "3000/tcp": {}
+        },
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "RACK_ENV=development",
+            "PROJECT_NAME=rails_hello",
+            "GLOBAL_PASSWORD=magic",
+            "SOME_PASSWORD=secret",
+            "RAILS_ENV=development",
+            "DATABASE_URL=postgres://postgres@db:5432/rails_hello_development",
+            "PATH=/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "RUBY_MAJOR=2.3",
+            "RUBY_VERSION=2.3.1",
+            "RUBY_DOWNLOAD_SHA256=b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd",
+            "RUBYGEMS_VERSION=2.6.7",
+            "BUNDLER_VERSION=1.13.4",
+            "GEM_HOME=/usr/local/bundle",
+            "BUNDLE_PATH=/usr/local/bundle",
+            "BUNDLE_BIN=/usr/local/bundle/bin",
+            "BUNDLE_SILENCE_ROOT_WARNING=1",
+            "BUNDLE_APP_CONFIG=/usr/local/bundle"
+        ],
+        "Cmd": [
+            "rails",
+            "server",
+            "-b",
+            "0.0.0.0"
+        ],
+        "Image": "faraday/rails_hello",
+        "Volumes": null,
+        "WorkingDir": "/usr/src/app",
+        "Entrypoint": null,
+        "OnBuild": null,
+        "Labels": {
+            "com.docker.compose.config-hash": "ff040c76ba24b1bac8d89e95cfb5ba7e29bd19423ed548a1436ae3c94bc6381a",
+            "com.docker.compose.container-number": "1",
+            "com.docker.compose.oneoff": "False",
+            "com.docker.compose.project": "railshello",
+            "com.docker.compose.service": "web",
+            "com.docker.compose.version": "1.8.1",
+            "io.fdy.cage.lib.coffee_rails": "/usr/src/app/vendor/coffee-rails",
+            "io.fdy.cage.pod": "frontend",
+            "io.fdy.cage.shell": "bash",
+            "io.fdy.cage.srcdir": "/usr/src/app",
+            "io.fdy.cage.target": "development",
+            "io.fdy.cage.test": "bundle exec rake"
+        }
+    },
+    "NetworkSettings": {
+        "Bridge": "",
+        "SandboxID": "ca243185e052f364f6f9e4141ee985397cda9c66a87258f8a8048a05452738cf",
+        "HairpinMode": false,
+        "LinkLocalIPv6Address": "",
+        "LinkLocalIPv6PrefixLen": 0,
+        "Ports": {
+            "3000/tcp": [
+                {
+                    "HostIp": "0.0.0.0",
+                    "HostPort": "3000"
+                }
+            ]
+        },
+        "SandboxKey": "/var/run/docker/netns/ca243185e052",
+        "SecondaryIPAddresses": null,
+        "SecondaryIPv6Addresses": null,
+        "EndpointID": "",
+        "Gateway": "",
+        "GlobalIPv6Address": "",
+        "GlobalIPv6PrefixLen": 0,
+        "IPAddress": "",
+        "IPPrefixLen": 0,
+        "IPv6Gateway": "",
+        "MacAddress": "",
+        "Networks": {
+            "railshello_default": {
+                "IPAMConfig": null,
+                "Links": null,
+                "Aliases": [
+                    "web",
+                    "774758ca1db8"
+                ],
+                "NetworkID": "4b237b1de0928a11bb399adaa249705b666bdc5dece3e9bdc260a630643bf945",
+                "EndpointID": "7d5e1e9df4bdf400654b96afdd1d42040c150a4f5b414f084c8fd5c95a9a906e",
+                "Gateway": "172.24.0.1",
+                "IPAddress": "172.24.0.3",
+                "IPPrefixLen": 16,
+                "IPv6Gateway": "",
+                "GlobalIPv6Address": "",
+                "GlobalIPv6PrefixLen": 0,
+                "MacAddress": "02:42:ac:18:00:03"
+            }
+        }
+    }
+}

--- a/src/fixtures/container_inspect_health.json
+++ b/src/fixtures/container_inspect_health.json
@@ -1,0 +1,242 @@
+{
+    "Id": "774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37",
+    "Created": "2016-10-25T11:59:37.858589354Z",
+    "Path": "rails",
+    "Args": [
+        "server",
+        "-b",
+        "0.0.0.0"
+    ],
+    "State": {
+        "Status": "running",
+        "Running": true,
+        "Paused": false,
+        "Restarting": false,
+        "OOMKilled": false,
+        "Dead": false,
+        "Pid": 13038,
+        "ExitCode": 0,
+        "Error": "",
+        "StartedAt": "2016-10-25T11:59:38.261828009Z",
+        "FinishedAt": "0001-01-01T00:00:00Z",
+        "Health": {
+            "Status": "healthy",
+            "FailingStreak": 0,
+            "Log": [
+                {
+                    "Start": "2018-12-31T16:02:55.845185754+03:00",
+                    "End": "2018-12-31T16:02:56.295432308+03:00",
+                    "ExitCode": 0,
+                    "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0OK\r100     2  100     2    0     0     45      0 --:--:-- --:--:-- --:--:--    46\n"
+                },
+                {
+                    "Start": "2018-12-31T16:03:26.295564382+03:00",
+                    "End": "2018-12-31T16:03:26.349103623+03:00",
+                    "ExitCode": 0,
+                    "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100     2  100     2    0     0    365      0 --:--:-- --:--:-- --:--:--   400\nOK"
+                },
+                {
+                    "Start": "2018-12-31T16:03:56.349227982+03:00",
+                    "End": "2018-12-31T16:03:56.402644196+03:00",
+                    "ExitCode": 0,
+                    "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100     2  100     2    0     0    350      0 --:--:-- --:--:-- --:--:--   400\nOK"
+                }
+            ]
+        }
+    },
+    "Image": "sha256:f5e9d349e7e5c0f6de798d732d83fa5e087695cd100149121f01c891e6167c13",
+    "ResolvConfPath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/resolv.conf",
+    "HostnamePath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/hostname",
+    "HostsPath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/hosts",
+    "LogPath": "/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37-json.log",
+    "Name": "/railshello_web_1",
+    "RestartCount": 0,
+    "Driver": "aufs",
+    "MountLabel": "",
+    "ProcessLabel": "",
+    "AppArmorProfile": "",
+    "ExecIDs": null,
+    "HostConfig": {
+        "Binds": [],
+        "ContainerIDFile": "",
+        "LogConfig": {
+            "Type": "json-file",
+            "Config": {}
+        },
+        "NetworkMode": "railshello_default",
+        "PortBindings": {
+            "3000/tcp": [
+                {
+                    "HostIp": "",
+                    "HostPort": "3000"
+                }
+            ]
+        },
+        "RestartPolicy": {
+            "Name": "",
+            "MaximumRetryCount": 0
+        },
+        "AutoRemove": false,
+        "VolumeDriver": "",
+        "VolumesFrom": [],
+        "CapAdd": null,
+        "CapDrop": null,
+        "Dns": null,
+        "DnsOptions": null,
+        "DnsSearch": null,
+        "ExtraHosts": null,
+        "GroupAdd": null,
+        "IpcMode": "",
+        "Cgroup": "",
+        "Links": null,
+        "OomScoreAdj": 0,
+        "PidMode": "",
+        "Privileged": false,
+        "PublishAllPorts": false,
+        "ReadonlyRootfs": false,
+        "SecurityOpt": null,
+        "UTSMode": "",
+        "UsernsMode": "",
+        "ShmSize": 67108864,
+        "Runtime": "runc",
+        "ConsoleSize": [
+            0,
+            0
+        ],
+        "Isolation": "",
+        "CpuShares": 0,
+        "Memory": 0,
+        "CgroupParent": "",
+        "BlkioWeight": 0,
+        "BlkioWeightDevice": null,
+        "BlkioDeviceReadBps": null,
+        "BlkioDeviceWriteBps": null,
+        "BlkioDeviceReadIOps": null,
+        "BlkioDeviceWriteIOps": null,
+        "CpuPeriod": 0,
+        "CpuQuota": 0,
+        "CpusetCpus": "",
+        "CpusetMems": "",
+        "Devices": null,
+        "DiskQuota": 0,
+        "KernelMemory": 0,
+        "MemoryReservation": 0,
+        "MemorySwap": 0,
+        "MemorySwappiness": -1,
+        "OomKillDisable": false,
+        "PidsLimit": 0,
+        "Ulimits": null,
+        "CpuCount": 0,
+        "CpuPercent": 0,
+        "IOMaximumIOps": 0,
+        "IOMaximumBandwidth": 0
+    },
+    "GraphDriver": {
+        "Name": "aufs",
+        "Data": null
+    },
+    "Mounts": [],
+    "Config": {
+        "Hostname": "774758ca1db8",
+        "Domainname": "",
+        "User": "",
+        "AttachStdin": false,
+        "AttachStdout": false,
+        "AttachStderr": false,
+        "ExposedPorts": {
+            "3000/tcp": {}
+        },
+        "Tty": false,
+        "OpenStdin": false,
+        "StdinOnce": false,
+        "Env": [
+            "RACK_ENV=development",
+            "PROJECT_NAME=rails_hello",
+            "GLOBAL_PASSWORD=magic",
+            "SOME_PASSWORD=secret",
+            "RAILS_ENV=development",
+            "DATABASE_URL=postgres://postgres@db:5432/rails_hello_development",
+            "PATH=/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "RUBY_MAJOR=2.3",
+            "RUBY_VERSION=2.3.1",
+            "RUBY_DOWNLOAD_SHA256=b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd",
+            "RUBYGEMS_VERSION=2.6.7",
+            "BUNDLER_VERSION=1.13.4",
+            "GEM_HOME=/usr/local/bundle",
+            "BUNDLE_PATH=/usr/local/bundle",
+            "BUNDLE_BIN=/usr/local/bundle/bin",
+            "BUNDLE_SILENCE_ROOT_WARNING=1",
+            "BUNDLE_APP_CONFIG=/usr/local/bundle"
+        ],
+        "Cmd": [
+            "rails",
+            "server",
+            "-b",
+            "0.0.0.0"
+        ],
+        "Image": "faraday/rails_hello",
+        "Volumes": null,
+        "WorkingDir": "/usr/src/app",
+        "Entrypoint": null,
+        "OnBuild": null,
+        "Labels": {
+            "com.docker.compose.config-hash": "ff040c76ba24b1bac8d89e95cfb5ba7e29bd19423ed548a1436ae3c94bc6381a",
+            "com.docker.compose.container-number": "1",
+            "com.docker.compose.oneoff": "False",
+            "com.docker.compose.project": "railshello",
+            "com.docker.compose.service": "web",
+            "com.docker.compose.version": "1.8.1",
+            "io.fdy.cage.lib.coffee_rails": "/usr/src/app/vendor/coffee-rails",
+            "io.fdy.cage.pod": "frontend",
+            "io.fdy.cage.shell": "bash",
+            "io.fdy.cage.srcdir": "/usr/src/app",
+            "io.fdy.cage.target": "development",
+            "io.fdy.cage.test": "bundle exec rake"
+        }
+    },
+    "NetworkSettings": {
+        "Bridge": "",
+        "SandboxID": "ca243185e052f364f6f9e4141ee985397cda9c66a87258f8a8048a05452738cf",
+        "HairpinMode": false,
+        "LinkLocalIPv6Address": "",
+        "LinkLocalIPv6PrefixLen": 0,
+        "Ports": {
+            "3000/tcp": [
+                {
+                    "HostIp": "0.0.0.0",
+                    "HostPort": "3000"
+                }
+            ]
+        },
+        "SandboxKey": "/var/run/docker/netns/ca243185e052",
+        "SecondaryIPAddresses": null,
+        "SecondaryIPv6Addresses": null,
+        "EndpointID": "",
+        "Gateway": "",
+        "GlobalIPv6Address": "",
+        "GlobalIPv6PrefixLen": 0,
+        "IPAddress": "",
+        "IPPrefixLen": 0,
+        "IPv6Gateway": "",
+        "MacAddress": "",
+        "Networks": {
+            "railshello_default": {
+                "IPAMConfig": null,
+                "Links": null,
+                "Aliases": [
+                    "web",
+                    "774758ca1db8"
+                ],
+                "NetworkID": "4b237b1de0928a11bb399adaa249705b666bdc5dece3e9bdc260a630643bf945",
+                "EndpointID": "7d5e1e9df4bdf400654b96afdd1d42040c150a4f5b414f084c8fd5c95a9a906e",
+                "Gateway": "172.24.0.1",
+                "IPAddress": "172.24.0.3",
+                "IPPrefixLen": 16,
+                "IPv6Gateway": "",
+                "GlobalIPv6Address": "",
+                "GlobalIPv6PrefixLen": 0,
+                "MacAddress": "02:42:ac:18:00:03"
+            }
+        }
+    }
+}

--- a/src/fixtures/stats_single_event.json
+++ b/src/fixtures/stats_single_event.json
@@ -1,0 +1,282 @@
+{
+    "read": "2015-04-09T07:02:08.48002208{}Z",
+    "memory_stats": {
+        "usage": 208437248,
+        "limit": 16854257664,
+        "failcnt": 0,
+        "stats": {
+            "unevictable": 0,
+            "total_inactive_file": 49876992,
+            "total_rss_huge": 6291456,
+            "hierarchical_memsw_limit": 18446744073709551615,
+            "total_cache": 178946048,
+            "total_mapped_file": 10809344,
+            "mapped_file": 10809344,
+            "pgfault": 99588,
+            "total_writeback": 0,
+            "hierarchical_memory_limit": 18446744073709551615,
+            "total_active_file": 129069056,
+            "rss_huge": 6291456,
+            "cache": 178946048,
+            "active_anon": 27213824,
+            "pgmajfault": 819,
+            "total_pgpgout": 153466,
+            "writeback": 0,
+            "pgpgout": 153466,
+            "swap": 0,
+            "total_active_anon": 27213824,
+            "total_unevictable": 0,
+            "total_pgfault": 99588,
+            "total_pgmajfault": 819,
+            "total_inactive_anon": 0,
+            "total_swap": 0,
+            "inactive_file": 49876992,
+            "pgpgin": 130731,
+            "total_pgpgin": 130731,
+            "rss": 29331456,
+            "active_file": 129069056,
+            "inactive_anon": 0,
+            "total_rss": 29331456
+        },
+        "max_usage": 318791680
+    },
+    "blkio_stats": {
+        "io_service_time_recursive": [
+            {
+                "major": 8,
+                "value": 2060941295,
+                "minor": 0,
+                "op": "Read"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Write"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Sync"
+            },
+            {
+                "major": 8,
+                "value": 2060941295,
+                "minor": 0,
+                "op": "Async"
+            },
+            {
+                "major": 8,
+                "value": 2060941295,
+                "minor": 0,
+                "op": "Total"
+            }
+        ],
+        "sectors_recursive": [
+            {
+                "major": 8,
+                "value": 294312,
+                "minor": 0,
+                "op": ""
+            }
+        ],
+        "io_service_bytes_recursive": [
+            {
+                "major": 8,
+                "value": 150687744,
+                "minor": 0,
+                "op": "Read"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Write"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Sync"
+            },
+            {
+                "major": 8,
+                "value": 150687744,
+                "minor": 0,
+                "op": "Async"
+            },
+            {
+                "major": 8,
+                "value": 150687744,
+                "minor": 0,
+                "op": "Total"
+            }
+        ],
+        "io_serviced_recursive": [
+            {
+                "major": 8,
+                "value": 484,
+                "minor": 0,
+                "op": "Read"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Write"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Sync"
+            },
+            {
+                "major": 8,
+                "value": 484,
+                "minor": 0,
+                "op": "Async"
+            },
+            {
+                "major": 8,
+                "value": 484,
+                "minor": 0,
+                "op": "Total"
+            }
+        ],
+        "io_time_recursive": [
+            {
+                "major": 8,
+                "value": 1814,
+                "minor": 0,
+                "op": ""
+            }
+        ],
+        "io_queue_recursive": [
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Read"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Write"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Sync"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Async"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Total"
+            }
+        ],
+        "io_merged_recursive": [
+            {
+                "major": 8,
+                "value": 79,
+                "minor": 0,
+                "op": "Read"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Write"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Sync"
+            },
+            {
+                "major": 8,
+                "value": 79,
+                "minor": 0,
+                "op": "Async"
+            },
+            {
+                "major": 8,
+                "value": 79,
+                "minor": 0,
+                "op": "Total"
+            }
+        ],
+        "io_wait_time_recursive": [
+            {
+                "major": 8,
+                "value": 5476872825,
+                "minor": 0,
+                "op": "Read"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Write"
+            },
+            {
+                "major": 8,
+                "value": 0,
+                "minor": 0,
+                "op": "Sync"
+            },
+            {
+                "major": 8,
+                "value": 5476872825,
+                "minor": 0,
+                "op": "Async"
+            },
+            {
+                "major": 8,
+                "value": 5476872825,
+                "minor": 0,
+                "op": "Total"
+            }
+        ]
+    },
+    "network": {
+        "tx_dropped": 0,
+        "rx_packets": 2742,
+        "rx_bytes": 5820720,
+        "tx_errors": 0,
+        "rx_errors": 0,
+        "tx_bytes": 158527,
+        "rx_dropped": 1,
+        "tx_packets": 2124
+    },
+    "cpu_stats": {
+        "cpu_usage": {
+            "usage_in_usermode": 18160000000,
+            "total_usage": 19194125000,
+            "percpu_usage": [
+                14110113138,
+                3245604417,
+                845722573,
+                992684872
+            ],
+            "usage_in_kernelmode": 1110000000
+        },
+        "system_cpu_usage": 1014488290000000,
+        "throttling_data": {
+            "throttled_time": 0,
+            "periods": 0,
+            "throttled_periods": 0
+        }
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 
+use super::container::HealthState;
 use super::ImageLayer;
 use container::{Container, ContainerInfo};
 use filesystem::FilesystemChange;
@@ -71,7 +72,18 @@ fn get_image_history() {
 #[test]
 fn get_container_info() {
     let response = get_container_info_response();
-    assert!(serde_json::from_str::<ContainerInfo>(&response).is_ok())
+    assert!(serde_json::from_str::<ContainerInfo>(&response).is_ok());
+
+    let response = get_container_info_response_with_healthcheck();
+    assert!(serde_json::from_str::<ContainerInfo>(&response).is_ok());
+}
+
+#[test]
+fn get_healthcheck_info() {
+    let response = get_container_info_response_with_healthcheck();
+    let container_info = serde_json::from_str::<ContainerInfo>(&response).unwrap();
+    assert!(container_info.State.Health.is_some());
+    assert!(container_info.State.Health.unwrap().Status == HealthState::Healthy);
 }
 
 #[test]
@@ -132,8 +144,12 @@ fn get_image_history_reponse() -> String {
     "#.into()
 }
 
-fn get_container_info_response() -> String {
-    r#"{"Id":"774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37","Created":"2016-10-25T11:59:37.858589354Z","Path":"rails","Args":["server","-b","0.0.0.0"],"State":{"Status":"running","Running":true,"Paused":false,"Restarting":false,"OOMKilled":false,"Dead":false,"Pid":13038,"ExitCode":0,"Error":"","StartedAt":"2016-10-25T11:59:38.261828009Z","FinishedAt":"0001-01-01T00:00:00Z"},"Image":"sha256:f5e9d349e7e5c0f6de798d732d83fa5e087695cd100149121f01c891e6167c13","ResolvConfPath":"/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/resolv.conf","HostnamePath":"/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/hostname","HostsPath":"/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/hosts","LogPath":"/var/lib/docker/containers/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37/774758ca1db8d05bd848d2b3456c8253a417a0511329692869df1cbe82978d37-json.log","Name":"/railshello_web_1","RestartCount":0,"Driver":"aufs","MountLabel":"","ProcessLabel":"","AppArmorProfile":"","ExecIDs":null,"HostConfig":{"Binds":[],"ContainerIDFile":"","LogConfig":{"Type":"json-file","Config":{}},"NetworkMode":"railshello_default","PortBindings":{"3000/tcp":[{"HostIp":"","HostPort":"3000"}]},"RestartPolicy":{"Name":"","MaximumRetryCount":0},"AutoRemove":false,"VolumeDriver":"","VolumesFrom":[],"CapAdd":null,"CapDrop":null,"Dns":null,"DnsOptions":null,"DnsSearch":null,"ExtraHosts":null,"GroupAdd":null,"IpcMode":"","Cgroup":"","Links":null,"OomScoreAdj":0,"PidMode":"","Privileged":false,"PublishAllPorts":false,"ReadonlyRootfs":false,"SecurityOpt":null,"UTSMode":"","UsernsMode":"","ShmSize":67108864,"Runtime":"runc","ConsoleSize":[0,0],"Isolation":"","CpuShares":0,"Memory":0,"CgroupParent":"","BlkioWeight":0,"BlkioWeightDevice":null,"BlkioDeviceReadBps":null,"BlkioDeviceWriteBps":null,"BlkioDeviceReadIOps":null,"BlkioDeviceWriteIOps":null,"CpuPeriod":0,"CpuQuota":0,"CpusetCpus":"","CpusetMems":"","Devices":null,"DiskQuota":0,"KernelMemory":0,"MemoryReservation":0,"MemorySwap":0,"MemorySwappiness":-1,"OomKillDisable":false,"PidsLimit":0,"Ulimits":null,"CpuCount":0,"CpuPercent":0,"IOMaximumIOps":0,"IOMaximumBandwidth":0},"GraphDriver":{"Name":"aufs","Data":null},"Mounts":[],"Config":{"Hostname":"774758ca1db8","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"ExposedPorts":{"3000/tcp":{}},"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["RACK_ENV=development","PROJECT_NAME=rails_hello","GLOBAL_PASSWORD=magic","SOME_PASSWORD=secret","RAILS_ENV=development","DATABASE_URL=postgres://postgres@db:5432/rails_hello_development","PATH=/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","RUBY_MAJOR=2.3","RUBY_VERSION=2.3.1","RUBY_DOWNLOAD_SHA256=b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd","RUBYGEMS_VERSION=2.6.7","BUNDLER_VERSION=1.13.4","GEM_HOME=/usr/local/bundle","BUNDLE_PATH=/usr/local/bundle","BUNDLE_BIN=/usr/local/bundle/bin","BUNDLE_SILENCE_ROOT_WARNING=1","BUNDLE_APP_CONFIG=/usr/local/bundle"],"Cmd":["rails","server","-b","0.0.0.0"],"Image":"faraday/rails_hello","Volumes":null,"WorkingDir":"/usr/src/app","Entrypoint":null,"OnBuild":null,"Labels":{"com.docker.compose.config-hash":"ff040c76ba24b1bac8d89e95cfb5ba7e29bd19423ed548a1436ae3c94bc6381a","com.docker.compose.container-number":"1","com.docker.compose.oneoff":"False","com.docker.compose.project":"railshello","com.docker.compose.service":"web","com.docker.compose.version":"1.8.1","io.fdy.cage.lib.coffee_rails":"/usr/src/app/vendor/coffee-rails","io.fdy.cage.pod":"frontend","io.fdy.cage.shell":"bash","io.fdy.cage.srcdir":"/usr/src/app","io.fdy.cage.target":"development","io.fdy.cage.test":"bundle exec rake"}},"NetworkSettings":{"Bridge":"","SandboxID":"ca243185e052f364f6f9e4141ee985397cda9c66a87258f8a8048a05452738cf","HairpinMode":false,"LinkLocalIPv6Address":"","LinkLocalIPv6PrefixLen":0,"Ports":{"3000/tcp":[{"HostIp":"0.0.0.0","HostPort":"3000"}]},"SandboxKey":"/var/run/docker/netns/ca243185e052","SecondaryIPAddresses":null,"SecondaryIPv6Addresses":null,"EndpointID":"","Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"IPAddress":"","IPPrefixLen":0,"IPv6Gateway":"","MacAddress":"","Networks":{"railshello_default":{"IPAMConfig":null,"Links":null,"Aliases":["web","774758ca1db8"],"NetworkID":"4b237b1de0928a11bb399adaa249705b666bdc5dece3e9bdc260a630643bf945","EndpointID":"7d5e1e9df4bdf400654b96afdd1d42040c150a4f5b414f084c8fd5c95a9a906e","Gateway":"172.24.0.1","IPAddress":"172.24.0.3","IPPrefixLen":16,"IPv6Gateway":"","GlobalIPv6Address":"","GlobalIPv6PrefixLen":0,"MacAddress":"02:42:ac:18:00:03"}}}}"#.to_string()
+fn get_container_info_response() -> &'static str {
+    include_str!("fixtures/container_inspect.json")
+}
+
+fn get_container_info_response_with_healthcheck() -> &'static str {
+    include_str!("fixtures/container_inspect_health.json")
 }
 
 fn get_processes_response() -> String {
@@ -165,5 +181,8 @@ fn get_stats_response() -> Response {
 }
 
 fn get_stats_single_event(n: u64) -> String {
-    format!("{{\"read\":\"2015-04-09T07:02:08.48002208{}Z\",\"network\":{{\"rx_bytes\":5820720,\"rx_packets\":2742,\"rx_errors\":0,\"rx_dropped\":1,\"tx_bytes\":158527,\"tx_packets\":2124,\"tx_errors\":0,\"tx_dropped\":0}},\"cpu_stats\":{{\"cpu_usage\":{{\"total_usage\":19194125000,\"percpu_usage\":[14110113138,3245604417,845722573,992684872],\"usage_in_kernelmode\":1110000000,\"usage_in_usermode\":18160000000}},\"system_cpu_usage\":1014488290000000,\"throttling_data\":{{\"periods\":0,\"throttled_periods\":0,\"throttled_time\":0}}}},\"memory_stats\":{{\"usage\":208437248,\"max_usage\":318791680,\"stats\":{{\"active_anon\":27213824,\"active_file\":129069056,\"cache\":178946048,\"hierarchical_memory_limit\":18446744073709551615,\"hierarchical_memsw_limit\":18446744073709551615,\"inactive_anon\":0,\"inactive_file\":49876992,\"mapped_file\":10809344,\"pgfault\":99588,\"pgmajfault\":819,\"pgpgin\":130731,\"pgpgout\":153466,\"rss\":29331456,\"rss_huge\":6291456,\"swap\":0,\"total_active_anon\":27213824,\"total_active_file\":129069056,\"total_cache\":178946048,\"total_inactive_anon\":0,\"total_inactive_file\":49876992,\"total_mapped_file\":10809344,\"total_pgfault\":99588,\"total_pgmajfault\":819,\"total_pgpgin\":130731,\"total_pgpgout\":153466,\"total_rss\":29331456,\"total_rss_huge\":6291456,\"total_swap\":0,\"total_unevictable\":0,\"total_writeback\":0,\"unevictable\":0,\"writeback\":0}},\"failcnt\":0,\"limit\":16854257664}},\"blkio_stats\":{{\"io_service_bytes_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"Read\",\"value\":150687744}},{{\"major\":8,\"minor\":0,\"op\":\"Write\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Sync\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Async\",\"value\":150687744}},{{\"major\":8,\"minor\":0,\"op\":\"Total\",\"value\":150687744}}],\"io_serviced_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"Read\",\"value\":484}},{{\"major\":8,\"minor\":0,\"op\":\"Write\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Sync\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Async\",\"value\":484}},{{\"major\":8,\"minor\":0,\"op\":\"Total\",\"value\":484}}],\"io_queue_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"Read\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Write\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Sync\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Async\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Total\",\"value\":0}}],\"io_service_time_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"Read\",\"value\":2060941295}},{{\"major\":8,\"minor\":0,\"op\":\"Write\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Sync\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Async\",\"value\":2060941295}},{{\"major\":8,\"minor\":0,\"op\":\"Total\",\"value\":2060941295}}],\"io_wait_time_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"Read\",\"value\":5476872825}},{{\"major\":8,\"minor\":0,\"op\":\"Write\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Sync\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Async\",\"value\":5476872825}},{{\"major\":8,\"minor\":0,\"op\":\"Total\",\"value\":5476872825}}],\"io_merged_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"Read\",\"value\":79}},{{\"major\":8,\"minor\":0,\"op\":\"Write\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Sync\",\"value\":0}},{{\"major\":8,\"minor\":0,\"op\":\"Async\",\"value\":79}},{{\"major\":8,\"minor\":0,\"op\":\"Total\",\"value\":79}}],\"io_time_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"\",\"value\":1814}}],\"sectors_recursive\":[{{\"major\":8,\"minor\":0,\"op\":\"\",\"value\":294312}}]}}}}", n).to_string()
+    let template = include_str!("fixtures/stats_single_event.json")
+        .to_string()
+        .replace("\n", "");
+    template.replace("{}", &n.to_string())
 }


### PR DESCRIPTION
- Added a missed `restart` api
- Added a healthcheck representation to State struct as an Optional (and a test for it)
- Cargo profile for tests; without optimizations should be a bit faster. 
- Added fixtures for a tests instead of using a long unreadable strings. 

I know, that it's probably a lot of changes for a single PR, if you want to review them separately (or if you're not interested in some of them, i.e tests) I'd do so. 