### PR TITLE
Feature/inspect image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,16 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +188,7 @@ dependencies = [
  "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -583,6 +594,19 @@ dependencies = [
 [[package]]
 name = "nodrop"
 version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1348,6 +1372,7 @@ dependencies = [
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
@@ -1397,6 +1422,8 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
 "checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ default = []
 ssl = ["openssl", "native-tls", "hyper-tls"]
 
 [dependencies]
+chrono = "0.4.6"
 error-chain = "0.12.0"
 backtrace-sys = "=0.1.23"
 futures = "0.1"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supported Api List.
 	- [x] `/build`
 	- [ ] `/build/prune`
 	- [x] `/images/create`
-	- [ ] `/images/{name}/json`
+	- [x] `/images/{name}/json`
 	- [x] `/images/{name}/history`
 	- [x] `/images/{name}/push`
 	- [ ] `/images/{name}/tag`

--- a/src/container.rs
+++ b/src/container.rs
@@ -94,7 +94,7 @@ pub struct ExecInfo {
 /// This type represents a `struct{}` in the Go code.
 pub type UnspecifiedObject = HashMap<String, String>;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Config {
     pub AttachStderr: bool,

--- a/src/container.rs
+++ b/src/container.rs
@@ -107,19 +107,22 @@ pub struct Config {
     pub Domainname: String,
     #[serde(deserialize_with = "null_to_default")]
     pub Entrypoint: Vec<String>,
-    pub Env: Option<Vec<String>>,
-    //#[serde(deserialize_with = "null_to_default")]
-    pub ExposedPorts: Option<HashMap<String, UnspecifiedObject>>,
+    #[serde(deserialize_with = "null_to_default")]
+    pub Env: Vec<String>,
+    #[serde(default = "Default::default")]
+    pub ExposedPorts: HashMap<String, UnspecifiedObject>,
     pub Hostname: String,
     pub Image: String,
+    #[serde(deserialize_with = "null_to_default")]
     pub Labels: HashMap<String, String>,
-    // TODO: We don't know exacly what this vec contains.
-    //pub OnBuild: Option<Vec<???>>,
+    #[serde(deserialize_with = "null_to_default")]
+    pub OnBuild: Vec<String>,
     pub OpenStdin: bool,
     pub StdinOnce: bool,
     pub Tty: bool,
     pub User: String,
-    pub Volumes: Option<HashMap<String, UnspecifiedObject>>,
+    #[serde(deserialize_with = "null_to_default")]
+    pub Volumes: UnspecifiedObject,
     pub WorkingDir: String,
 }
 
@@ -588,5 +591,3 @@ where
     let actual: Option<T> = Option::deserialize(de)?;
     Ok(actual.unwrap_or_default())
 }
-
-

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -15,7 +15,7 @@ pub use credentials::{Credential, UserPassword};
 use errors::*;
 use filesystem::FilesystemChange;
 use hyper_client::HyperClient;
-use image::{Image, ImageId};
+use image::{SummaryImage, Image, ImageId};
 use options::*;
 use process::{Process, Top};
 use stats::StatsReader;
@@ -654,6 +654,17 @@ impl Docker {
         }
     }
 
+    /// Inspect an image
+    ///
+    pub fn inspect_image(&self, name: &str) -> Result<Image> {
+        self.http_client()
+            .get(
+                self.headers(),
+                &format!("/images/{}/json", name)
+            )
+            .and_then(api_result)
+    }
+
     /// Push an image
     ///
     /// # NOTE
@@ -747,7 +758,7 @@ impl Docker {
     ///
     /// # API
     /// /images/json
-    pub fn images(&self, all: bool) -> Result<Vec<Image>> {
+    pub fn images(&self, all: bool) -> Result<Vec<SummaryImage>> {
         self.http_client()
             .get(self.headers(), &format!("/images/json?a={}", all as u32))
             .and_then(api_result)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -15,7 +15,7 @@ pub use credentials::{Credential, UserPassword};
 use errors::*;
 use filesystem::FilesystemChange;
 use hyper_client::HyperClient;
-use image::{SummaryImage, Image, ImageId};
+use image::{Image, ImageId, SummaryImage};
 use options::*;
 use process::{Process, Top};
 use stats::StatsReader;
@@ -658,10 +658,7 @@ impl Docker {
     ///
     pub fn inspect_image(&self, name: &str) -> Result<Image> {
         self.http_client()
-            .get(
-                self.headers(),
-                &format!("/images/{}/json", name)
-            )
+            .get(self.headers(), &format!("/images/{}/json", name))
             .and_then(api_result)
     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -40,7 +40,8 @@ pub struct Image {
     pub RepoDigests: Vec<String>,
     pub Parent: String,
     pub Comment: String,
-    #[serde(with = "format::chrono")]
+    #[serde(with = "format::datetime_rfc3339")]
+    /// https://github.com/moby/moby/blob/611b23c1a0e9a9f440165a331964923fd1116256/daemon/images/image_inspect.go#L72
     pub Created: DateTime<FixedOffset>,
     pub Container: String,
     //pub ContainerConfig: ContainerConfig,
@@ -89,7 +90,7 @@ impl ImageId {
 }
 
 pub mod format {
-    pub mod chrono {
+    pub mod datetime_rfc3339 {
         use chrono::DateTime;
         use chrono::offset::FixedOffset;
         use serde::Serializer;

--- a/src/image.rs
+++ b/src/image.rs
@@ -71,6 +71,7 @@ pub struct GraphDriver {
 pub struct RootFS {
     pub Type: String,
     pub Layers: Vec<String>,
+    #[serde(default = "Default::default")]
     pub BaseLayer: String,
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -4,6 +4,8 @@ use serde::de::{DeserializeOwned, Deserializer};
 use serde::Deserialize;
 use std::{fmt, result};
 
+use container::Config;
+
 fn null_to_default<'de, D, T>(de: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
@@ -32,7 +34,7 @@ pub struct SummaryImage {
 }
 
 /// Type of /images/{}/json api
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Image {
     pub Id: String,
@@ -44,16 +46,32 @@ pub struct Image {
     /// https://github.com/moby/moby/blob/611b23c1a0e9a9f440165a331964923fd1116256/daemon/images/image_inspect.go#L72
     pub Created: DateTime<FixedOffset>,
     pub Container: String,
-    //pub ContainerConfig: ContainerConfig,
+    pub ContainerConfig: Config,
     pub DockerVersion: String,
     pub Author: String,
-    //pub Config: Config,
+    pub Config: Config,
     pub Architecture: String,
     pub Os: String,
     pub Size: i64,
     pub VirtualSize: i64,
-    //pub GraphDriver: GraphDriver,
-    //pub RootFS: RootFS,
+    pub GraphDriver: GraphDriver,
+    pub RootFS: RootFS,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(non_snake_case)]
+pub struct GraphDriver {
+    pub Name: String,
+    #[serde(deserialize_with = "null_to_default")]
+    pub Data: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(non_snake_case)]
+pub struct RootFS {
+    pub Type: String,
+    pub Layers: Vec<String>,
+    pub BaseLayer: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,8 +1,8 @@
+use chrono::offset::FixedOffset;
+use chrono::DateTime;
 use serde::de::{DeserializeOwned, Deserializer};
 use serde::Deserialize;
 use std::{fmt, result};
-use chrono::DateTime;
-use chrono::offset::FixedOffset;
 
 fn null_to_default<'de, D, T>(de: D) -> Result<T, D::Error>
 where
@@ -91,24 +91,25 @@ impl ImageId {
 
 pub mod format {
     pub mod datetime_rfc3339 {
-        use chrono::DateTime;
         use chrono::offset::FixedOffset;
-        use serde::Serializer;
+        use chrono::DateTime;
         use serde::de::{self, Deserialize, Deserializer};
+        use serde::Serializer;
 
         pub fn serialize<S>(dt: &DateTime<FixedOffset>, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer,
+        where
+            S: Serializer,
         {
             let str = dt.to_rfc3339();
             serializer.serialize_str(&str)
         }
 
         pub fn deserialize<'de, D>(de: D) -> Result<DateTime<FixedOffset>, D::Error>
-        where D: Deserializer<'de>,
+        where
+            D: Deserializer<'de>,
         {
             let str = String::deserialize(de)?;
             DateTime::parse_from_rfc3339(&str).map_err(de::Error::custom)
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![recursion_limit = "1024"]
 
 extern crate base64;
+extern crate chrono;
 extern crate byteorder;
 #[macro_use]
 extern crate error_chain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@
 #![recursion_limit = "1024"]
 
 extern crate base64;
-extern crate chrono;
 extern crate byteorder;
+extern crate chrono;
 #[macro_use]
 extern crate error_chain;
 extern crate futures;

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,7 +4,7 @@ use super::ImageLayer;
 use container::{Container, ContainerInfo};
 use filesystem::FilesystemChange;
 use hyper_client::Response;
-use image::{SummaryImage, Image};
+use image::{Image, SummaryImage};
 use process::Top;
 use serde_json;
 use stats::{Stats, StatsReader};

--- a/src/test.rs
+++ b/src/test.rs
@@ -57,7 +57,7 @@ fn get_image_list() {
 #[test]
 fn get_image() {
     let response = get_image_response();
-    assert!(serde_json::from_str::<Image>(&response).is_ok());
+    println!("response: {:?}", serde_json::from_str::<Image>(&response));
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,7 +4,7 @@ use super::ImageLayer;
 use container::{Container, ContainerInfo};
 use filesystem::FilesystemChange;
 use hyper_client::Response;
-use image::Image;
+use image::{SummaryImage, Image};
 use process::Top;
 use serde_json;
 use stats::{Stats, StatsReader};
@@ -48,10 +48,16 @@ fn get_system_info() {
 }
 
 #[test]
-fn get_images() {
-    let response = get_images_response();
-    let images: Vec<Image> = serde_json::from_str(&response).unwrap();
+fn get_image_list() {
+    let response = get_image_list_response();
+    let images: Vec<SummaryImage> = serde_json::from_str(&response).unwrap();
     assert_eq!(3, images.len());
+}
+
+#[test]
+fn get_image() {
+    let response = get_image_response();
+    assert!(serde_json::from_str::<Image>(&response).is_ok());
 }
 
 #[test]
@@ -94,7 +100,12 @@ fn get_system_info_response() -> String {
     "{\"Containers\":6,\"Debug\":0,\"DockerRootDir\":\"/var/lib/docker\",\"Driver\":\"btrfs\",\"DriverStatus\":[[\"Build Version\",\"Btrfs v3.17.1\"],[\"Library Version\",\"101\"]],\"ExecutionDriver\":\"native-0.2\",\"ID\":\"WG63:3NIU:TSI2:FV7J:IL2O:YPXA:JR3F:XEKT:JZVR:JA6T:QMYE:B4SB\",\"IPv4Forwarding\":1,\"Images\":190,\"IndexServerAddress\":\"https://index.docker.io/v1/\",\"InitPath\":\"/usr/libexec/docker/dockerinit\",\"InitSha1\":\"30c93967bdc3634b6036e1a76fd547bbe171b264\",\"KernelVersion\":\"3.18.6\",\"Labels\":null,\"MemTotal\":16854257664,\"MemoryLimit\":1,\"NCPU\":4,\"NEventsListener\":0,\"NFd\":68,\"NGoroutines\":95,\"Name\":\"core\",\"OperatingSystem\":\"CoreOS 607.0.0\",\"RegistryConfig\":{\"IndexConfigs\":{\"docker.io\":{\"Mirrors\":null,\"Name\":\"docker.io\",\"Official\":true,\"Secure\":true}},\"InsecureRegistryCIDRs\":[\"127.0.0.0/8\"]},\"SwapLimit\":1}".to_string()
 }
 
-fn get_images_response() -> String {
+// `docker inspect debian:wheely-2019- |  jq '.[]'
+fn get_image_response() -> String {
+    r###"{"Id":"sha256:301e280df919c411b7c2b049f938f3e26e4269a9be4a8ac3babce1ede930be0f","RepoTags":["debian:wheezy-20190204-slim"],"RepoDigests":["debian@sha256:8af4c5d36bf9e97bd9e9d32f4b23c30197269a8690d1aee6771beb7bdc744d5d"],"Parent":"","Comment":"","Created":"2019-02-06T03:31:46.89466512Z","Container":"bde93de20096d0e854d13ce9e3e8a506b3a2b7798c051bd1e2bebb644ad60b9a","ContainerConfig":{"Hostname":"bde93de20096","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"Cmd":["/bin/sh","-c","#(nop) ","CMD [\"bash\"]"],"ArgsEscaped":true,"Image":"sha256:cf2bd8704a6c5c4fc4b7a9801c5dacac8ddd3fc699b6e02227119b168d8cf2a9","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":{}},"DockerVersion":"18.06.1-ce","Author":"","Config":{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"Cmd":["bash"],"ArgsEscaped":true,"Image":"sha256:cf2bd8704a6c5c4fc4b7a9801c5dacac8ddd3fc699b6e02227119b168d8cf2a9","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":null},"Architecture":"amd64","Os":"linux","Size":46924746,"VirtualSize":46924746,"GraphDriver":{"Data":null,"Name":"aufs"},"RootFS":{"Type":"layers","Layers":["sha256:745d171eb8c3d69f788da3a1b053056231ad140b80be71d6869229846a1f3a77"]},"Metadata":{"LastTagTime":"0001-01-01T00:00:00Z"}}"###.into()
+}
+
+fn get_image_list_response() -> String {
     "[{\"Created\":1428533761,\"Id\":\"533da4fa223bfbca0f56f65724bb7a4aae7a1acd6afa2309f370463eaf9c34a4\",\"ParentId\":\"84ac0b87e42afe881d36f03dea817f46893f9443f9fc10b64ec279737384df12\",\"RepoTags\":[\"ghmlee/rust:nightly\"],\"Size\":0,\"VirtualSize\":806688288},{\"Created\":1371157430,\"Id\":\"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158\",\"ParentId\":\"\",\"RepoTags\":[],\"Size\":0,\"VirtualSize\":0},
     {\"Created\":1371157430,\"Id\":\"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158\",\"ParentId\":\"\",\"RepoTags\":null,\"Size\":0,\"VirtualSize\":0}]".to_string()
 }


### PR DESCRIPTION
Support inspecting image api.
Improve deserialize format of `Config` type.

## New feature
- Add image inspect API wrapper `Docker::inspect_image`

## Breaking change
- `Image` type is renamed to `SummaryImage`. The name `Image` is used for the response type of the new API (`inspect_image`)
