### PR TITLE
fix: check supported container restart api

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Supported Api List.
 	- [ ] `/containers/{id}/resize`
 	- [x] `/containers/{id}/start`
 	- [x] `/containers/{id}/stop`
-	- [ ] `/containers/{id}/restart`
+	- [x] `/containers/{id}/restart`
 	- [x] `/containers/{id}/kill`
 	- [ ] `/containers/{id}/update`
 	- [ ] `/containers/{id}/rename`


### PR DESCRIPTION
Supporting restart container api is implemented within #33 .
