### PR TITLE
bump up 0.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.0.12"
+version = "0.0.13"
 authors = ["eldesh <nephits@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/eldesh/dockworker"


### PR DESCRIPTION
`release 0.0.13`

## Improvements
- using `failure` create for representing any errors instead of `error-chain`.