### PR TITLE
Specify API version when querying Docker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ### Environment
 
 - Docker
-    - API 1.31.1
+    - API version 1.26
 
 - OS
     - Linux (developped in Ubuntu(amd64))

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -44,6 +44,9 @@ pub static DEFAULT_DOCKER_HOST: &'static str = "unix:///var/run/docker.sock";
 #[cfg(windows)]
 pub static DEFAULT_DOCKER_HOST: &'static str = "tcp://localhost:2375";
 
+/// The default `DOCKER_API_VERSION` that we support.
+pub const DEFAULT_DOCKER_API_VERSION: &str = "1.26";
+
 /// The default directory in which to look for our Docker certificate
 /// files.
 pub fn default_cert_path() -> Result<PathBuf> {
@@ -191,10 +194,10 @@ impl Docker {
     #[cfg(unix)]
     pub fn connect_with_unix(addr: &str) -> Result<Docker> {
         if addr.starts_with("unix://") {
-            let client = HyperClient::connect_with_unix(&addr[7..]);
+            let client = HyperClient::connect_with_unix(&addr[7..])?;
             Ok(Docker::new(client, Protocol::Unix))
         } else {
-            let client = HyperClient::connect_with_unix(addr);
+            let client = HyperClient::connect_with_unix(addr)?;
             Ok(Docker::new(client, Protocol::Unix))
         }
     }

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fs::File;
 use std::path::Path;
 use std::result;
@@ -270,8 +271,9 @@ fn request_with_redirect<T: Into<hyper::Body> + Sync + Send + 'static + Clone>(
 
 impl HyperClient {
     fn new(client: Client, base: Uri) -> result::Result<Self, Error> {
-        // Append Docker API version to base URI
-        let mut ver = DEFAULT_DOCKER_API_VERSION.to_string();
+        // Append Docker API version to base
+        let mut ver =
+            env::var("DOCKER_API_VERSION").unwrap_or(DEFAULT_DOCKER_API_VERSION.to_string());
         ver.insert_str(0, "v");
         let base = join_uri(&base, &ver)?;
 


### PR DESCRIPTION
This should partially fix GH-21.

Not sure if `HyperClient::new()` is the best place to query Docker-specific environment variables, but otherwise the code wouldn't be DRY.