### PR TITLE
Fix race condition in attach_container test

### DIFF
--- a/docker/attach/entrypoint.sh
+++ b/docker/attach/entrypoint.sh
@@ -9,6 +9,17 @@ if [ $# -ne 2 ]; then
 	usage
 fi
 
+# Wait for SIGUSR1 before continuing
+# (http://mywiki.wooledge.org/SignalTrap#When_is_the_signal_handled.3F)
+if [[ ! -z "${WAIT_BEFORE_CONTINUING}" ]]
+then
+	pid=
+	trap '[[ $pid ]] && kill "$pid"' SIGUSR1
+	sleep 10000 & pid=$!
+	wait
+	pid=
+fi
+
 stdout=$1
 stderr=$2
 


### PR DESCRIPTION
It's possible for `test-iostream` container to terminate before `docker.attach_container()` is called, which causes this test to hang.

This patch makes sure that we have a chance to attach to the container before it exits.