### PR TITLE
get rid of dead code compiler warnings

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -639,10 +639,6 @@ impl Read for LogResponse {
 }
 
 impl LogResponse {
-    fn new(res: Response) -> Self {
-        Self { res }
-    }
-
     pub fn output(&mut self) -> errors::Result<String> {
         let mut str = String::new();
         self.res.read_to_string(&mut str)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 extern crate base64;
 extern crate byteorder;
 extern crate chrono;
-#[macro_use]
 extern crate failure;
 extern crate futures;
 extern crate http;


### PR DESCRIPTION
```
zsh/4 9286 [1]  (git)-[eliminate-dead-code-warnings]-% cargo version
cargo 1.31.0 (339d9f9c8 2018-11-16)

zsh/4 9289  (git)-[master]-% cargo build
   Compiling dockworker v0.0.14 (/home/wayne/projects/dockworker)
warning: unused `#[macro_use]` import
 --> src/lib.rs:9:1
  |
9 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default

warning: method is never used: `new`
   --> src/container.rs:642:5
    |
642 |     fn new(res: Response) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(dead_code)] on by default

    Finished dev [unoptimized + debuginfo] target(s) in 8.55s
```