### PR TITLE
Check the headers has Location

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1126,6 +1126,48 @@ mod tests {
     }
 
     #[test]
+    fn create_double_stop_container() {
+        let docker = Docker::connect_with_defaults().unwrap();
+        let (name, tag) = ("hello-world", "linux");
+        assert!(docker
+            .create_image(name, tag)
+            .map(|sts| sts.for_each(|st| println!("{:?}", st)))
+            .is_ok());
+        let mut create = ContainerCreateOptions::new(&format!("{}:{}", name, tag));
+        create.host_config(ContainerHostConfig::new());
+
+        assert!(docker
+            .create_container(
+                Some("dockworker_test_create_remove_stop_container"),
+                &create
+            )
+            .is_ok());
+        assert!(docker
+            .stop_container(
+                "dockworker_test_create_remove_stop_container",
+                Duration::from_secs(10)
+            )
+            .is_ok());
+        assert!(docker
+            .stop_container(
+                "dockworker_test_create_remove_stop_container",
+                Duration::from_secs(10)
+            )
+            .is_ok());
+        assert!(docker
+            .remove_container(
+                "dockworker_test_create_remove_stop_container",
+                None,
+                None,
+                None
+            )
+            .is_ok());
+        assert!(docker
+            .remove_image(&format!("{}:{}", name, tag), None, None)
+            .is_ok());
+    }
+
+    #[test]
     fn test_container_info() {
         let docker = Docker::connect_with_defaults().unwrap();
         let (name, tag) = ("alpine", "3.8");

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -118,6 +118,15 @@ fn no_content(res: Response) -> result::Result<(), Error> {
     }
 }
 
+/// Expect 204 NoContent or 304 NotModified
+fn no_content_or_not_modified(res: Response) -> result::Result<(), Error> {
+    if res.status == StatusCode::NO_CONTENT || res.status == StatusCode::NOT_MODIFIED {
+        Ok(())
+    } else {
+        Err(serde_json::from_reader::<_, DockerError>(res)?.into())
+    }
+}
+
 /// Ignore succeed response
 ///
 /// Read whole response body, then ignore it.
@@ -323,7 +332,7 @@ impl Docker {
                 &format!("/containers/{}/stop?{}", id, param.finish()),
                 "",
             )
-            .and_then(no_content)
+            .and_then(no_content_or_not_modified)
     }
 
     /// Kill a container

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1128,7 +1128,7 @@ mod tests {
     #[test]
     fn create_double_stop_container() {
         let docker = Docker::connect_with_defaults().unwrap();
-        let (name, tag) = ("hello-world", "linux");
+        let (name, tag) = ("alpine", "3.9");
         assert!(docker
             .create_image(name, tag)
             .map(|sts| sts.for_each(|st| println!("{:?}", st)))

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -184,7 +184,7 @@ fn with_redirect<T: Into<hyper::Body> + Sync + Send + 'static + Clone>(
             let mut request = request_builder(&method, &uri, &headers);
             let uri_parts = http::uri::Parts::from(uri.clone());
 
-            if !res.status().is_redirection() {
+            if !res.status().is_redirection() || res.headers().get("Location").is_none() {
                 Box::new(Ok(res).into_future())
                     as Box<
                         hyper::rt::Future<


### PR DESCRIPTION
Hi, eldesh-san.

The case of `res.status().is_redirection() == true` and `res.headers().get("Location") == None`,
dockworker crashes.

For instance, when a call of `stop_container` to an already stopped container,
`304 Not Modified` is returned, and it crashes.

This pull request fixes them.

Thank you.