### PR TITLE
Add support for (experimental) docker checkpoint feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "actively-developed" }
 # OpenSSL is fairly hard to build on certain platforms, especially if you
 # want to produce release binaries. So we disable it by default.
 default = []
+experimental = []
 
 # Enable OpenSSL both directly and for Hyper.
 ssl = ["openssl", "native-tls", "hyper-tls"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Supported Api List.
 	- [x] `/containers/{id}/archive`
 	- [ ] `/containers/{id}/prune`
 
+- checkpoints
+    - [x] `/containers/{id}/checkpoints`
+
 - exec
     - [x] `/exec/{id}/start`
     - [x] `/exec/{id}/json`

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "experimental")]
+#[derive(Debug, Deserialize)]
+#[allow(non_snake_case)]
+pub struct Checkpoint {
+    pub Name: String,
+}
+
+#[cfg(feature = "experimental")]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CheckpointCreateOptions {
+    pub checkpoint_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    // None -> set by docker to /var/lib/docker/containers/{containerid}/checkpoints
+    pub checkpoint_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    // None -> set by docker to false, container keeps running by default
+    pub exit: Option<bool>,
+}
+
+#[cfg(feature = "experimental")]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CheckpointDeleteOptions {
+    pub checkpoint_id: String,
+    // None -> set by docker to /var/lib/docker/containers/{containerid}/checkpoints
+    pub checkpoint_dir: Option<String>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ extern crate tokio;
 extern crate unix_socket;
 extern crate url;
 
+pub mod checkpoint;
 pub mod container;
 pub mod credentials;
 mod docker;


### PR DESCRIPTION
New functions for the main docker object:
- resume_container_from_checkpoint: Start a container from a previous made checkpoint
- list_container_checkpoints: Get checkpoints from a container
- checkpoint_container: Take a snapshot of the container
- delete_checkpoint: Delete specified checkpoint from filesystem

Due to the checkpoint related features being only available in dockers experimental mode, also added new feature 'experimental'  

Runs only on linux kernel versions prior to 5.0.0.23 (regarding https://github.com/checkpoint-restore/criu/issues/860#issuecomment-557042894) and docker versions above 18.10 (regarding  https://github.com/moby/moby/issues/35691#issuecomment-480350129)