### PR TITLE
bump up 0.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.0.15"
+version = "0.0.16"
 authors = ["eldesh <nephits@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/eldesh/dockworker"


### PR DESCRIPTION
`release 0.0.16`

## New features
- support `/networks` APIs (#76)

## Bug fixes
- fix `stop_container` crashes try to stopping a container which is already stopped

