### PR TITLE
make the response module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod image;
 pub mod network;
 mod options;
 pub mod process;
-mod response;
+pub mod response;
 pub mod signal;
 pub mod stats;
 pub mod system;


### PR DESCRIPTION
This PR makes the response module public.
Although data coming from /images/create is not reliable, checking the data is the only way to measure the progress of docker pull and thus considered useful.