### PR TITLE
Workaround for hyper hangup

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2080,11 +2080,17 @@ mod tests {
         let count2 = count.clone();
         std::thread::spawn(move || {
             let docker = Docker::connect_with_defaults().unwrap();
-            while count2.fetch_add(1, Ordering::Relaxed) < 2000 {
+            while count2.fetch_add(1, Ordering::Relaxed) < 500 {
                 let _events = docker.events(None, None, None).unwrap();
             }
         });
-        std::thread::sleep(std::time::Duration::from_secs(10));
-        assert_eq!(count.load(Ordering::Relaxed), 2001);
+        loop {
+            let c = count.load(Ordering::Relaxed);
+            if c == 501 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            assert_ne!(count.load(Ordering::Relaxed), c);
+        }
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -825,7 +825,7 @@ impl Docker {
         }
         let res =
             self.http_client()
-                .post(&headers, &format!("/images/create?{}", param.finish()), "")?;
+                .post(&headers, &format!("images/create?{}", param.finish()), "")?;
         if res.status.is_success() {
             Ok(Box::new(
                 BufReader::new(res)
@@ -1146,7 +1146,7 @@ impl Docker {
         }
 
         self.http_client()
-            .get(self.headers(), &format!("/events?{}", param.finish()))
+            .get(self.headers(), &format!("events?{}", param.finish()))
             .and_then(|res| {
                 Ok(Box::new(
                     serde_json::Deserializer::from_reader(res)
@@ -2085,6 +2085,6 @@ mod tests {
             }
         });
         std::thread::sleep(std::time::Duration::from_secs(10));
-        assert_eq!(count.load(Ordering::Relaxed), 2000);
+        assert_eq!(count.load(Ordering::Relaxed), 2001);
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2070,4 +2070,21 @@ mod tests {
             .remove_container(&container.id, None, None, None)
             .unwrap();
     }
+
+    #[test]
+    fn workaround_hyper_hangup() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+        std::thread::spawn(move || {
+            let docker = Docker::connect_with_defaults().unwrap();
+            while count2.fetch_add(1, Ordering::Relaxed) < 2000 {
+                let _events = docker.events(None, None, None).unwrap();
+            }
+        });
+        std::thread::sleep(std::time::Duration::from_secs(10));
+        assert_eq!(count.load(Ordering::Relaxed), 2000);
+    }
 }


### PR DESCRIPTION
As I described in https://github.com/hyperium/hyper/issues/2306, hyper 0.12 seems have a bug that the event loop hangs up at a very low probability.
This PR introduces an easy (but fairly ungly) workaround for this issue.
Namely, it remotes the first "/" from the query path "/events?" to avoid unnecessary redirection handling.
Currently all GET queries from dockworker should look like "http://localhost:3275//events?" and this PR just removes the redundant slash.
I only removed the slash from the "/events" and "/images/create" APIs because they are the only APIs that return iterators.

I confirmed that the test I added in this PR first failed and after the second commit it succeeded.