### PR TITLE
bump up 0.0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "dockworker"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "backtrace-sys",
  "base64 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dockworker"
 description = "Docker daemon API client. (a fork of Faraday's boondock)"
-version = "0.0.18"
+version = "0.0.19"
 authors = ["eldesh <nephits@gmail.com>"]
 license = "Apache-2.0"
 homepage = "https://github.com/eldesh/dockworker"


### PR DESCRIPTION
`release 0.0.19`

## New features
- Add ability to filter containers by status (#94)

## Changes
- Bump up hyper to 0.13 (#99)