### PR TITLE
Workaround for hyper deadlock

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2088,11 +2088,11 @@ mod tests {
         let count2 = count.clone();
         std::thread::spawn(move || {
             let docker = Docker::connect_with_defaults().unwrap();
-            while count2.fetch_add(1, Ordering::Relaxed) < 2000 {
+            while count2.fetch_add(1, Ordering::Relaxed) < 1000 {
                 let _events = docker.events(None, None, None).unwrap();
             }
         });
-        std::thread::sleep(std::time::Duration::from_secs(10));
-        assert_eq!(count.load(Ordering::Relaxed), 2001);
+        std::thread::sleep(std::time::Duration::from_secs(60));
+        assert_eq!(count.load(Ordering::Relaxed), 1001);
     }
 }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -2092,7 +2092,7 @@ mod tests {
                 let _events = docker.events(None, None, None).unwrap();
             }
         });
-        std::thread::sleep(std::time::Duration::from_secs(60));
+        std::thread::sleep(std::time::Duration::from_secs(120));
         assert_eq!(count.load(Ordering::Relaxed), 1001);
     }
 }

--- a/src/hyper_client.rs
+++ b/src/hyper_client.rs
@@ -236,7 +236,12 @@ impl HyperClient {
     #[cfg(unix)]
     pub fn connect_with_unix(path: &str) -> Self {
         let url = hyperlocal::Uri::new(path, "").into();
-        let client = hyper::Client::builder().build::<_, hyper::Body>(hyperlocal::UnixConnector);
+        // Prevent from using connection pooling.
+        // See https://github.com/hyperium/hyper/issues/2312.
+        let client: hyper::Client<_> = hyper::Client::builder()
+            .pool_idle_timeout(std::time::Duration::from_millis(0))
+            .pool_max_idle_per_host(0)
+            .build(hyperlocal::UnixConnector);
         Self::new(Client::UnixClient(client), url)
     }
 


### PR DESCRIPTION
This is a workaround for the deadlock bug which I confirmed in hyper 0.12 and 0.13.
In #98 I concluded that this was a bug in tokio 0.2 but it was incorrect.
Before and after commit f934777 the result of `cargo test docker::tests::workaround_hyper_hangup -- --ignored` changes from failed to succeed.